### PR TITLE
feat: add StorageProvider abstraction for runtime-agnostic storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Universal workflow automation engine for Deno.
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/vseplet/shibui)](https://github.com/vseplet/shibui/pulse)
 [![GitHub last commit](https://img.shields.io/github/last-commit/vseplet/shibui)](https://github.com/vseplet/shibui/commits/main)
 
-> **Note:** This package is under active development. Contributions, feedback, and pull requests are welcome!
+> **Note:** This package is under active development. Contributions, feedback,
+> and pull requests are welcome!
 
 ## Contents
 

--- a/deno.json
+++ b/deno.json
@@ -40,6 +40,7 @@
     "$shibui/emitters": "./source/emitters.ts",
     "$shibui/constants": "./source/constants.ts",
     "$shibui/components": "./source/components/mod.ts",
+    "$shibui/providers": "./source/providers/mod.ts",
     "$helpers/types": "./source/helpers/types.ts",
     "$helpers": "./source/helpers/mod.ts",
     "@std/path": "jsr:@std/path@0.224.0",

--- a/deno.json
+++ b/deno.json
@@ -17,6 +17,7 @@
   },
   "tasks": {
     "test": "deno test --allow-all --unstable-broadcast-channel --unstable-kv ./tests/",
+    "test:coverage": "deno test --allow-all --unstable-broadcast-channel --unstable-kv --coverage=coverage ./tests/",
     "pub-dry": "deno publish --dry-run --allow-slow-types",
     "example:simple-task": "deno run --allow-all --unstable-broadcast-channel --unstable-kv ./examples/01-simple-task-with-trigger.ts",
     "example:task-chaining": "deno run --allow-all --unstable-broadcast-channel --unstable-kv ./examples/02-task-chaining.ts",

--- a/source/components/Runner.ts
+++ b/source/components/Runner.ts
@@ -13,6 +13,7 @@
 import type { Pot } from "$shibui/entities";
 import {
   SourceType,
+  type StorageProvider,
   type TAnyCore,
   type TDoHandlerResult,
   type TEventDrivenLogger,
@@ -33,7 +34,7 @@ import { promiseWithTimeout } from "$helpers";
 
 export default class Runner {
   #core: TAnyCore;
-  #kv: Deno.Kv | null = null;
+  #provider: StorageProvider | null = null;
   #log: TEventDrivenLogger;
   #spicy: TSpicy;
   #tasks: { [name: string]: TTask } = {};
@@ -47,8 +48,8 @@ export default class Runner {
     });
   }
 
-  init(kv: Deno.Kv): void {
-    this.#kv = kv;
+  init(provider: StorageProvider): void {
+    this.#provider = provider;
   }
 
   registerTask(task: TTask) {

--- a/source/components/Tester.ts
+++ b/source/components/Tester.ts
@@ -16,6 +16,7 @@ import type { Pot } from "$shibui/entities";
 import STRS from "$shibui/strings";
 import {
   SourceType,
+  type StorageProvider,
   type TAnyCore,
   type TasksStorage,
   type TEventDrivenLogger,
@@ -30,7 +31,7 @@ import { Filler, Runner } from "$shibui/components";
 
 export class Tester {
   #core: TAnyCore;
-  #kv: Deno.Kv | null = null;
+  #provider: StorageProvider | null = null;
   #log: TEventDrivenLogger;
   #filler: Filler;
   #runner: Runner;
@@ -56,10 +57,10 @@ export class Tester {
     this.#runner = new Runner(core, this.#spicy);
   }
 
-  async init(kv: Deno.Kv): Promise<void> {
-    this.#kv = kv;
-    await this.#filler.init(kv);
-    this.#runner.init(kv);
+  async init(provider: StorageProvider): Promise<void> {
+    this.#provider = provider;
+    await this.#filler.init(provider);
+    this.#runner.init(provider);
   }
 
   registerTask(task: TTask) {

--- a/source/helpers/mod.ts
+++ b/source/helpers/mod.ts
@@ -1,2 +1,13 @@
 export { promiseWithTimeout } from "./promiseWithTimeout.ts";
 export { syncPromiseWithTimeout } from "./syncPromiseWithTimeout.ts";
+export {
+  detectRuntime,
+  exit,
+  getRuntimeInfo,
+  getRuntimeVersion,
+  isBun,
+  isDeno,
+  isNode,
+  type Runtime,
+  runtime,
+} from "./runtime.ts";

--- a/source/helpers/runtime.ts
+++ b/source/helpers/runtime.ts
@@ -1,0 +1,93 @@
+/**
+ * Runtime environment detection utilities
+ */
+
+export type Runtime = "deno" | "bun" | "node" | "unknown";
+
+/**
+ * Detect current JavaScript runtime environment
+ */
+export function detectRuntime(): Runtime {
+  // Deno
+  // @ts-ignore: Deno global
+  if (typeof Deno !== "undefined" && Deno.version?.deno) {
+    return "deno";
+  }
+
+  // Bun
+  // @ts-ignore: Bun global
+  if (typeof Bun !== "undefined") {
+    return "bun";
+  }
+
+  // Node.js
+  // deno-lint-ignore no-process-global
+  if (typeof process !== "undefined" && process.versions?.node) {
+    return "node";
+  }
+
+  return "unknown";
+}
+
+/**
+ * Cached runtime value (detected once)
+ */
+export const runtime: Runtime = detectRuntime();
+
+/**
+ * Runtime check helpers
+ */
+export const isDeno = runtime === "deno";
+export const isBun = runtime === "bun";
+export const isNode = runtime === "node";
+
+/**
+ * Get runtime version
+ */
+export function getRuntimeVersion(): string {
+  switch (runtime) {
+    case "deno":
+      // @ts-ignore: Deno global
+      return Deno.version.deno;
+    case "bun":
+      // @ts-ignore: Bun global
+      return Bun.version;
+    case "node":
+      // deno-lint-ignore no-process-global
+      return process.versions.node;
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Exit process with code (works in deno/node/bun)
+ */
+export function exit(code: number = 0): void {
+  switch (runtime) {
+    case "deno":
+      // @ts-ignore: Deno global
+      Deno.exit(code);
+      break;
+    case "bun":
+    case "node":
+      // deno-lint-ignore no-process-global
+      process.exit(code);
+      break;
+    default:
+      throw new Error(`exit() not supported in runtime: ${runtime}`);
+  }
+}
+
+/**
+ * Runtime info object
+ */
+export function getRuntimeInfo() {
+  return {
+    runtime,
+    version: getRuntimeVersion(),
+    isDeno,
+    isBun,
+    isNode,
+  };
+}

--- a/source/mod.ts
+++ b/source/mod.ts
@@ -22,6 +22,7 @@ import type {
   TTaskBuilder,
   TWorkflowBuilder,
 } from "$shibui/types";
+import { exit } from "$helpers";
 import type { Constructor } from "$helpers/types";
 import type { Pot } from "$shibui/entities";
 import {
@@ -131,7 +132,7 @@ export const runCI = <S extends TSpicy>(
     storage: "memory",
     logging: false,
   }).then((value) => {
-    Deno.exit(value ? 0 : -1);
+    exit(value ? 0 : 1);
   });
 };
 
@@ -222,6 +223,22 @@ export {
 // New v1.0 API - chain and pipe utilities
 export { chain, type ChainConfig, pipe, type Transform } from "./chain.ts";
 
+// Storage providers
+export { DenoKvProvider, MemoryProvider } from "$shibui/providers";
+
+// Runtime detection
+export {
+  detectRuntime,
+  exit,
+  getRuntimeInfo,
+  getRuntimeVersion,
+  isBun,
+  isDeno,
+  isNode,
+  type Runtime,
+  runtime,
+} from "$helpers";
+
 // Re-export everything from submodules for convenience
 export { ContextPot, CoreStartPot } from "$shibui/pots";
 
@@ -269,6 +286,9 @@ export type {
   PotInput,
   PotLike,
   PotWithData,
+  // Storage provider
+  StorageEntry,
+  StorageProvider,
   // Core types
   TAnyCore,
   TAnyTaskDoHandler,

--- a/source/providers/DenoKvProvider.ts
+++ b/source/providers/DenoKvProvider.ts
@@ -1,0 +1,96 @@
+import type { StorageEntry, StorageProvider, TPot } from "$shibui/types";
+
+/**
+ * Storage provider implementation using Deno KV.
+ * This is the default provider for Shibui.
+ *
+ * @example
+ * ```typescript
+ * // In-memory (for tests)
+ * const provider = new DenoKvProvider(":memory:");
+ *
+ * // Persistent storage
+ * const provider = new DenoKvProvider("./data/shibui.db");
+ *
+ * core({ provider })
+ * ```
+ */
+export class DenoKvProvider implements StorageProvider {
+  #kv: Deno.Kv | null = null;
+  #path: string | undefined;
+
+  constructor(path?: string) {
+    this.#path = path;
+  }
+
+  async open(): Promise<void> {
+    this.#kv = await Deno.openKv(this.#path);
+  }
+
+  close(): void {
+    this.#kv?.close();
+    this.#kv = null;
+  }
+
+  async enqueue(pot: TPot): Promise<void> {
+    if (!this.#kv) {
+      throw new Error("Provider not initialized. Call open() first.");
+    }
+    await this.#kv.enqueue(pot);
+  }
+
+  listen(handler: (pot: TPot) => void): void {
+    if (!this.#kv) {
+      throw new Error("Provider not initialized. Call open() first.");
+    }
+    this.#kv.listenQueue((message: unknown) => {
+      handler(message as TPot);
+    });
+  }
+
+  async store(key: string[], pot: TPot): Promise<void> {
+    if (!this.#kv) {
+      throw new Error("Provider not initialized. Call open() first.");
+    }
+    await this.#kv.set(key, pot);
+  }
+
+  async retrieve(key: string[]): Promise<TPot | null> {
+    if (!this.#kv) {
+      throw new Error("Provider not initialized. Call open() first.");
+    }
+    const result = await this.#kv.get<TPot>(key);
+    return result.value;
+  }
+
+  async remove(key: string[]): Promise<void> {
+    if (!this.#kv) {
+      throw new Error("Provider not initialized. Call open() first.");
+    }
+    await this.#kv.delete(key);
+  }
+
+  async *scan(prefix: string[]): AsyncIterableIterator<StorageEntry> {
+    if (!this.#kv) {
+      throw new Error("Provider not initialized. Call open() first.");
+    }
+    const entries = this.#kv.list<TPot>({ prefix });
+    for await (const entry of entries) {
+      yield {
+        key: entry.key as string[],
+        pot: entry.value,
+      };
+    }
+  }
+
+  async removeMany(keys: string[][]): Promise<void> {
+    if (!this.#kv) {
+      throw new Error("Provider not initialized. Call open() first.");
+    }
+    const atomic = this.#kv.atomic();
+    for (const key of keys) {
+      atomic.delete(key);
+    }
+    await atomic.commit();
+  }
+}

--- a/source/providers/MemoryProvider.ts
+++ b/source/providers/MemoryProvider.ts
@@ -1,0 +1,94 @@
+import type { StorageEntry, StorageProvider, TPot } from "$shibui/types";
+
+/**
+ * In-memory storage provider for testing and development.
+ * Data is not persisted between restarts.
+ *
+ * @example
+ * ```typescript
+ * const provider = new MemoryProvider();
+ * core({ provider })
+ * ```
+ */
+export class MemoryProvider implements StorageProvider {
+  #storage = new Map<string, TPot>();
+  #queue: TPot[] = [];
+  #handler: ((pot: TPot) => void) | null = null;
+  #processing = false;
+
+  async open(): Promise<void> {
+    // No-op for memory provider
+  }
+
+  close(): void {
+    this.#storage.clear();
+    this.#queue = [];
+    this.#handler = null;
+    this.#processing = false;
+  }
+
+  enqueue(pot: TPot): Promise<void> {
+    this.#queue.push(pot);
+    this.#processQueue();
+    return Promise.resolve();
+  }
+
+  listen(handler: (pot: TPot) => void): void {
+    this.#handler = handler;
+    this.#processQueue();
+  }
+
+  #processQueue(): void {
+    if (this.#processing || !this.#handler) return;
+    this.#processing = true;
+
+    queueMicrotask(() => {
+      while (this.#queue.length > 0 && this.#handler) {
+        const pot = this.#queue.shift()!;
+        this.#handler(pot);
+      }
+      this.#processing = false;
+    });
+  }
+
+  store(key: string[], pot: TPot): Promise<void> {
+    this.#storage.set(this.#keyToString(key), pot);
+    return Promise.resolve();
+  }
+
+  retrieve(key: string[]): Promise<TPot | null> {
+    return Promise.resolve(this.#storage.get(this.#keyToString(key)) ?? null);
+  }
+
+  remove(key: string[]): Promise<void> {
+    this.#storage.delete(this.#keyToString(key));
+    return Promise.resolve();
+  }
+
+  async *scan(prefix: string[]): AsyncIterableIterator<StorageEntry> {
+    const prefixStr = this.#keyToString(prefix);
+    for (const [keyStr, pot] of this.#storage) {
+      if (keyStr.startsWith(prefixStr)) {
+        yield {
+          key: this.#stringToKey(keyStr),
+          pot,
+        };
+      }
+    }
+  }
+
+  removeMany(keys: string[][]): Promise<void> {
+    for (const key of keys) {
+      this.#storage.delete(this.#keyToString(key));
+    }
+    return Promise.resolve();
+  }
+
+  #keyToString(key: string[]): string {
+    return key.join("\x00");
+  }
+
+  #stringToKey(str: string): string[] {
+    return str.split("\x00");
+  }
+}

--- a/source/providers/mod.ts
+++ b/source/providers/mod.ts
@@ -1,0 +1,2 @@
+export { DenoKvProvider } from "./DenoKvProvider.ts";
+export { MemoryProvider } from "./MemoryProvider.ts";


### PR DESCRIPTION
- Add StorageProvider interface with queue and KV operations
- Implement DenoKvProvider for Deno KV backend
- Implement MemoryProvider for in-memory storage
- Add runtime detection helpers (isDeno, isBun, isNode)
- Add cross-platform exit() function
- Support "auto" storage option (DenoKv for Deno, Memory for others)
- Refactor Core, Distributor, Filler, Tester to use StorageProvider
- Remove direct Deno KV dependencies from core components